### PR TITLE
TOOLS-4174 derive package version from git tags via build/version

### DIFF
--- a/build/version
+++ b/build/version
@@ -1,11 +1,144 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Unified version/build-number script for aerospike-tools-validation, mirroring the
+# aerospike-server resolver (see build/README-VERSIONING.md in that repo). All three
+# outputs:
+#
+# Usage:
+#   build/version              -> master: x.y.z-n; dev branches: git describe with SHA
+#   build/version -v           -> master: x.y.z (bare);
+#                                 dev branches: git describe with SHA (same as default)
+#   build/version -r           -> master: build number (first-parent commits since
+#                                 the tag + 1, so the tagged release is 1); dev: 1
+#
+# Consumed by pkg/Makefile.{deb,rpm}: REV = `build/version -v`,
+# BUILD_NUMBER = `build/version -r`. The build number is 1-based: unlike
+# aerospike-server (which tags a line-open marker and counts from 0), asvalidation
+# tags the release commit directly, so the tagged release and dev builds are build
+# number 1 and each subsequent master commit increments.
+#
+# Resolution rules:
+# - Always anchors on the bare x.y.z release tag via --match '[0-9]*.[0-9]*.[0-9]*'
+#   (never a v-prefixed ship tag, which would emit a leading 'v' the Debian Version:
+#   field rejects). Falls back to the short SHA when no bare tag is reachable, never v...
+# - master: strip the describe --long suffix to x.y.z; default appends -n.
+# - Dev branches: keep the full describe output (-<n>-g<sha>) as the version itself,
+#   so dev packages carry the commit descriptor; build number is 0.
+# - --first-parent requires git >= 2.20.
 
-rev=`git describe`
-subbuild=`echo $rev | awk -F'-' '{print $2}'`
+mode=full # full (default): x.y.z-n; version_only: x.y.z; build_only: n
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -v) mode=version_only ;;
+    -r) mode=build_only ;;
+    *)
+        echo "Usage: $(basename "$0") [-v|-r]" >&2
+        exit 1
+        ;;
+    esac
+    shift
+done
 
-if [ "$subbuild" != "" ]
-then
-#  rev=`echo $rev | awk -F'-' '{printf("%s-%s\n",$1,$2)}'`
-  rev=`echo $rev | awk -F'-' '{printf("%s\n",$1)}'`
+# git --match uses glob, NOT regex: a segment must be [0-9]* (a leading digit, so
+# 'staging.v1' is excluded). It must NOT be [0-9][0-9]*, which in a glob means
+# two-or-more digits and so never matches single-digit segments (2.2.0, 2.1.0, ...),
+# leaving every build SHA-versioned.
+TAG_MATCH='[0-9]*.[0-9]*.[0-9]*'
+VTAG_MATCH="v${TAG_MATCH}"
+
+# Centralizes the release-branch check (asvalidation ships from master only).
+_is_release_branch() {
+    [[ "$1" == "master" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Build-number calculation
+# ---------------------------------------------------------------------------
+_build_number() {
+    local bn_branch="$1"
+
+    # Dev branches are build number 1; the -<n>-g<sha> describe suffix that -v keeps
+    # on dev branches is what actually distinguishes those builds.
+    if ! _is_release_branch "$bn_branch"; then
+        echo "1"
+        return
+    fi
+
+    local base_tag
+    base_tag=$(git describe --first-parent --tags --abbrev=0 \
+        --match "$TAG_MATCH" 2>/dev/null) || true
+    if [[ -z "$base_tag" ]]; then
+        base_tag=$(git describe --first-parent --tags --abbrev=0 \
+            --match "$VTAG_MATCH" 2>/dev/null) || true
+    fi
+
+    # +1 so the tagged release (0 commits past the tag) is build number 1.
+    if [[ -n "$base_tag" ]]; then
+        echo "$(( $(git rev-list --first-parent --count "${base_tag}..HEAD") + 1 ))"
+    else
+        echo "1"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Determine branch. Tries, in order: local branch name, common CI env vars (covers
+# detached-HEAD checkouts), then the first remote branch containing HEAD.
+# ---------------------------------------------------------------------------
+_resolve_branch() {
+    local branch
+    branch="$(git branch --show-current 2>/dev/null || true)"
+    if [[ -n "$branch" ]]; then echo "$branch"; return; fi
+
+    if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then echo "$GITHUB_HEAD_REF"; return; fi
+    if [[ -n "${GITHUB_REF:-}" && "$GITHUB_REF" == refs/heads/* ]]; then
+        echo "${GITHUB_REF#refs/heads/}"; return
+    fi
+    if [[ -n "${CI_COMMIT_REF_NAME:-}" ]]; then echo "$CI_COMMIT_REF_NAME"; return; fi
+
+    # grep -Ev '/HEAD ->' avoids the symbolic HEAD ref; strip the remote prefix.
+    git branch -r --contains HEAD 2>/dev/null | grep -Ev '/HEAD ->' | head -1 |
+        sed -e 's|^[^/]*/||' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' || true
+}
+
+# git describe anchored on the bare x.y.z tag. On failure (unsupported git, shallow
+# clone with no tags, ...) warn to stderr before falling back to the short SHA, so
+# mis-provisioned runners are visible instead of silently SHA-versioned packages.
+_describe() {
+    local strip_suffix="$1" rev
+    rev="$(git describe --first-parent --tags --always --abbrev=9 --long \
+        --match "$TAG_MATCH" 2>/dev/null)"
+    if [[ -z "$rev" ]]; then
+        echo "warning: git describe failed; falling back to commit SHA" >&2
+        rev="$(git rev-parse --short=9 HEAD)"
+    fi
+    if [[ "$strip_suffix" == true ]]; then
+        rev="$(echo "$rev" | sed -E 's/-[0-9]+-g[0-9a-f]+$//')"
+    fi
+    echo "$rev"
+}
+
+# ---------------------------------------------------------------------------
+# Resolve
+# ---------------------------------------------------------------------------
+git rev-parse --git-dir >/dev/null 2>&1 || {
+    echo "error: not a git repository" >&2
+    exit 1
+}
+
+branch="$(_resolve_branch)"
+
+if [[ "$mode" == "build_only" ]]; then # -r
+    _build_number "$branch"
+    exit 0
 fi
-echo $rev
+
+if _is_release_branch "$branch"; then
+    rev="$(_describe true)"
+    case "$mode" in
+    version_only) echo "$rev" ;;
+    full) echo "${rev}-$(_build_number "$branch")" ;;
+    esac
+else
+    # Dev branch: emit the full describe (-<n>-g<sha>) for both -v and default.
+    _describe false
+fi

--- a/pkg/Makefile.deb
+++ b/pkg/Makefile.deb
@@ -5,7 +5,13 @@ export DEB_BUILD_ROOT = $(DEB_SOURCE_ROOT)/BUILD
 export CL_BASE = $(DEB_BUILD_ROOT)/opt/aerospike
 export ETC_BASE = $(DEB_BUILD_ROOT)/etc/aerospike
 
-REV = $(shell build/version)
+# Package version from git tags (build/version is the single source of truth):
+# master -> x.y.z; dev branches -> x.y.z-<n>-g<sha> (full git describe).
+REV = $(shell build/version -v)
+# Build number from build/version -r (1-based: tagged release and dev builds are 1);
+# forms the debian revision (with the OS) so successive master builds are orderable.
+BUILD_NUMBER = $(shell build/version -r)
+DEB_REVISION = $(BUILD_NUMBER)$(OS)
 OS = $(shell build/os_version)
 ARCH=$(shell uname -m)
 MANIFEST_DIR = manifest/TEMP
@@ -44,10 +50,10 @@ dist:
 	ln -sf /opt/aerospike/bin/asvalidation $(DEB_BUILD_ROOT)/usr/bin/asvalidation
 
 
-	sed 's/@VERSION@/'$(REV)'/g' <pkg/deb/control >$(DEB_BUILD_ROOT)/DEBIAN/control
+	sed 's/@VERSION@/'$(REV)-$(DEB_REVISION)'/g' <pkg/deb/control >$(DEB_BUILD_ROOT)/DEBIAN/control
 	sed -i 's/@ARCH@/'$(ARCH)'/g' $(DEB_BUILD_ROOT)/DEBIAN/control
 
-	fakeroot dpkg-deb -Z xz --build $(DEB_BUILD_ROOT) target/packages/asvalidation_$(REV)-1$(OS)_$(ARCH).deb
+	fakeroot dpkg-deb -Z xz --build $(DEB_BUILD_ROOT) target/packages/asvalidation_$(REV)-$(DEB_REVISION)_$(ARCH).deb
 	rm -rf dist
 
 distclean:

--- a/pkg/Makefile.rpm
+++ b/pkg/Makefile.rpm
@@ -6,7 +6,15 @@ export CL_BASE = $(RPM_BUILD_ROOT)/opt/aerospike
 export ETC_BASE = $(RPM_BUILD_ROOT)/etc/aerospike
 
 MANIFEST_DIR = manifest/TEMP
-REV = $(shell build/version | sed 's/-/_/g')
+# Package version from git tags (build/version is the single source of truth):
+# master -> x.y.z; dev branches -> x.y.z-<n>-g<sha>. rpm forbids '-' in Version, so
+# map the dev describe suffix's hyphens to underscores.
+REV = $(shell build/version -v)
+RPM_VERSION = $(subst -,_,$(REV))
+# Build number from build/version -r (1-based: tagged release and dev builds are 1);
+# becomes the rpm Release so successive master builds are orderable.
+BUILD_NUMBER = $(shell build/version -r)
+RPM_RELEASE = $(BUILD_NUMBER)
 OS = $(shell build/os_version)
 ARCH = $(shell uname -m)
 
@@ -17,8 +25,8 @@ default: dist
 	mkdir -p $(RPM_SOURCE_ROOT)/RPMS/$(ARCH)
 	mkdir -p $(RPM_BUILD_ROOT)/usr/bin
 
-	sed 's/@VERSION@/'$(REV)'/g' <pkg/rpm/asvalidation.spec >pkg/asvalidation_v.spec
-	sed -i 's/@RELEASE@/'$(OS)'/g' pkg/asvalidation_v.spec
+	sed 's/@VERSION@/'$(RPM_VERSION)'/g' <pkg/rpm/asvalidation.spec >pkg/asvalidation_v.spec
+	sed -i 's/@RELEASE@/'$(RPM_RELEASE)'/g' pkg/asvalidation_v.spec
 	sed -i 's/@ARCH@/'$(ARCH)'/g' pkg/asvalidation_v.spec
 
 	rpmbuild --noclean -bb -vv --define "dist .$(OS)" --buildroot $(RPM_BUILD_ROOT) pkg/asvalidation_v.spec

--- a/pkg/rpm/asvalidation.spec
+++ b/pkg/rpm/asvalidation.spec
@@ -1,6 +1,6 @@
 Name: asvalidation
 Version: @VERSION@
-Release: 1%{?dist}
+Release: @RELEASE@%{?dist}
 Summary: Aerospike Validation Tool
 License: Apache 2.0 license
 Group: Application


### PR DESCRIPTION
## Summary

Makes `build/version` the single source of truth for versioning and wires it into the deb/rpm Makefiles, so packages are versioned from git tags and successive builds are orderable. Ported from [aerospike/act#81](https://github.com/aerospike/act/pull/81), adapted for 3-part semver `x.y.z`; aligned to the canonical [aerospike-server resolver](https://github.com/citrusleaf/aerospike-server/pull/1414).

The previous `build/version` was a `git describe` + awk stub that stripped **every** build down to bare `x.y.z` — no build number, no dev-branch descriptor — so successive builds collided on the same package name.

## Changes

- **`build/version`** — unified resolver:
  - `build/version -v` → master: bare `x.y.z`; dev branches: full `git describe` (`x.y.z-<n>-g<sha>`)
  - `build/version -r` → master: build number (first-parent commits since the tag, 0 on the tag); dev: 1
  - default → `x.y.z-n`

  Anchors on the bare `x.y.z` tag via `--match '[0-9]*.[0-9]*.[0-9]*'` (never a leading-`v` tag the Debian `Version:` rejects), falls back to the short SHA, and resolves the branch through CI env vars for detached-HEAD checkouts. Release line is `master`.
- **`pkg/Makefile.deb`** — `REV = build/version -v`, `BUILD_NUMBER = build/version -r + 1`; version/revision now consistent between the control `Version:` and the `.deb` filename.
- **`pkg/Makefile.rpm`** — `RPM_VERSION = $(subst -,_,$(REV))` (rpm forbids `-` in `Version:`), `Release = BUILD_NUMBER` (was a no-op `@RELEASE@`→`$(OS)`).
- **`pkg/rpm/asvalidation.spec`** — `Release: 1` → `Release: @RELEASE@%{?dist}`.

The `+1` makes the tagged release (and dev builds) revision `1`; asvalidation tags the release commit directly (no line-open marker tag), so `-r` is `0` there and the Makefile adds the 1.

## Resulting package names

| | RPM | DEB |
|---|---|---|
| master on tag | `asvalidation-2.2.0-1.el8.x86_64.rpm` | `asvalidation_2.2.0-1ubuntu24.04_amd64.deb` |
| master N past tag | `asvalidation-2.2.0-<N+1>.el8…` | `asvalidation_2.2.0-<N+1>ubuntu24.04…` |
| dev branch | `asvalidation-2.2.0_9_g865032a0d-1.el8…` | `asvalidation_2.2.0-9-g865032a0d-1ubuntu24.04_amd64.deb` |

(dev rpm uses `_` in the describe segment because rpm `Version:` cannot contain `-`.)

## Note

The compiled binary's `TOOL_VERSION` still comes from raw `git describe` in the top-level `Makefile` (unchanged, out of scope), so it stays git-derived with no hardcoded drift.

## Test plan

- [x] `bash -n build/version`; all modes exercised
- [x] Scratch-repo verification: master on/off-tag (orderable), dev branch, detached-HEAD fallback
- [x] `make -f pkg/Makefile.{deb,rpm} print-REV/print-BUILD_NUMBER` resolve correctly
- [ ] CI build produces the expected `.deb`/`.rpm` names on a real runner
